### PR TITLE
Admin create new assets

### DIFF
--- a/app/controllers/asset_controller.py
+++ b/app/controllers/asset_controller.py
@@ -198,3 +198,37 @@ class AssetController:
             return self.asset_view.render_error(str(e), 403)
         except Exception as e:
             return self.asset_view.render_error(str(e), 500)
+    
+    def create_asset_with_initial_fraction(self):
+        """
+        Handle complete asset creation workflow with initial fraction and value history.
+        This is the admin endpoint for creating assets with all necessary components.
+        
+        Returns:
+            Response: JSON response with created asset, fraction, and value history data
+        """
+        try:
+            data = request.get_json()
+            if not data:
+                return self.asset_view.render_error("No JSON data provided", 400)
+            
+            # Extract asset data, owner_id, and adjusted_by
+            asset_data = {k: v for k, v in data.items() if k not in ['owner_id', 'adjusted_by']}
+            owner_id = data.get('owner_id')
+            adjusted_by = data.get('adjusted_by')
+            
+            if not owner_id:
+                return self.asset_view.render_error("owner_id is required", 400)
+            
+            if not adjusted_by:
+                return self.asset_view.render_error("adjusted_by is required", 400)
+            
+            # Create asset with initial fraction and value history
+            result = self.asset_service.create_asset_with_initial_fraction(asset_data, owner_id, adjusted_by)
+            
+            return self.asset_view.render_asset_with_fraction_created(result)
+            
+        except ValueError as e:
+            return self.asset_view.render_error(str(e), 400)
+        except Exception as e:
+            return self.asset_view.render_error(str(e), 500)

--- a/app/models.py
+++ b/app/models.py
@@ -50,6 +50,7 @@ class Asset(Base):
     
     asset_id = Column(BigInteger, primary_key=True, autoincrement=True)
     asset_name = Column(Text, nullable=False)
+    asset_description = Column(Text)
     total_unit = Column(BigInteger, nullable=False)
     unit_min = Column(BigInteger, nullable=False)
     unit_max = Column(BigInteger, nullable=False)
@@ -63,6 +64,7 @@ class Asset(Base):
         return {
             'asset_id': self.asset_id,
             'asset_name': self.asset_name,
+            'asset_description': self.asset_description,
             'total_unit': self.total_unit,
             'unit_min': self.unit_min,
             'unit_max': self.unit_max,

--- a/app/routes/assets.py
+++ b/app/routes/assets.py
@@ -24,6 +24,18 @@ def create_asset():
     return asset_controller.create_asset()
 
 
+@bp.route('/with-initial-fraction', methods=['POST'])
+def create_asset_with_initial_fraction():
+    """
+    Create a new asset with initial fraction and value history.
+    This is the complete admin workflow for asset creation.
+    
+    Returns:
+        JSON response with created asset, fraction, and value history data
+    """
+    return asset_controller.create_asset_with_initial_fraction()
+
+
 @bp.route('/<int:asset_id>', methods=['GET'])
 def get_asset(asset_id):
     """

--- a/app/services/asset_service.py
+++ b/app/services/asset_service.py
@@ -3,7 +3,7 @@ Asset service for asset-related business logic.
 """
 
 from app import db
-from app.models import Asset
+from app.models import Asset, Fraction, AssetValueHistory
 from datetime import datetime
 from typing import Optional, List, Dict, Any
 
@@ -23,18 +23,33 @@ class AssetService:
             Asset: Created asset instance
             
         Raises:
-            ValueError: If required fields are missing
+            ValueError: If required fields are missing or invalid
         """
         required_fields = ['asset_name', 'total_unit', 'unit_min', 'unit_max', 'total_value']
         for field in required_fields:
             if field not in asset_data or asset_data[field] is None:
                 raise ValueError(f"Missing required field: {field}")
         
+        # Validate units constraints
+        total_unit = asset_data['total_unit']
+        unit_min = asset_data['unit_min']
+        unit_max = asset_data['unit_max']
+        
+        if unit_min > unit_max:
+            raise ValueError("unit_min cannot be greater than unit_max")
+        
+        if total_unit < unit_min:
+            raise ValueError("total_unit cannot be less than unit_min")
+        
+        if total_unit > unit_max:
+            raise ValueError("total_unit cannot be greater than unit_max")
+        
         asset = Asset(
             asset_name=asset_data['asset_name'],
-            total_unit=asset_data['total_unit'],
-            unit_min=asset_data['unit_min'],
-            unit_max=asset_data['unit_max'],
+            asset_description=asset_data.get('asset_description'),
+            total_unit=total_unit,
+            unit_min=unit_min,
+            unit_max=unit_max,
             total_value=asset_data['total_value'],
             created_at=datetime.utcnow()
         )
@@ -91,7 +106,7 @@ class AssetService:
             return None
         
         # Update allowed fields
-        allowed_fields = ['asset_name', 'total_unit', 'unit_min', 'unit_max', 'total_value']
+        allowed_fields = ['asset_name', 'asset_description', 'total_unit', 'unit_min', 'unit_max', 'total_value']
         for field in allowed_fields:
             if field in asset_data:
                 setattr(asset, field, asset_data[field])
@@ -134,3 +149,80 @@ class AssetService:
             return []
         
         return asset.fractions
+    
+    @staticmethod
+    def create_asset_with_initial_fraction(asset_data: Dict[str, Any], owner_id: int, admin_user_id: int = None) -> Dict[str, Any]:
+        """
+        Create a new asset with initial fraction and value history record.
+        This is the complete workflow for admin asset creation.
+        
+        Args:
+            asset_data: Dictionary containing asset information
+            owner_id: User ID who will own the initial fraction
+            admin_user_id: User ID of the admin creating the asset (optional)
+            
+        Returns:
+            Dictionary containing created asset and fraction data
+            
+        Raises:
+            ValueError: If required fields are missing or invalid
+        """
+        # Validate owner exists
+        from app.models import User
+        owner = User.query.get(owner_id)
+        if not owner:
+            raise ValueError("Owner user not found")
+        
+        # Validate admin user exists and is a manager
+        if admin_user_id:
+            admin_user = User.query.get(admin_user_id)
+            if not admin_user:
+                raise ValueError("Admin user not found")
+            if not admin_user.is_manager:
+                raise PermissionError("Only managers can create assets")
+        
+        # Create the asset first
+        asset = AssetService.create_asset(asset_data)
+        
+        try:
+            # Calculate value per unit
+            total_value = float(asset_data['total_value'])
+            total_unit = asset_data['total_unit']
+            value_per_unit = round(total_value / total_unit, 2)
+            
+            # Create initial fraction with all units
+            fraction = Fraction(
+                asset_id=asset.asset_id,
+                owner_id=owner_id,
+                parent_fraction_id=None,
+                units=total_unit,
+                is_active=True,
+                created_at=datetime.utcnow(),
+                value_perunit=int(value_per_unit * 100)  # Store as integer (cents)
+            )
+            
+            db.session.add(fraction)
+            
+            # Create initial value history record
+            value_history = AssetValueHistory(
+                asset_id=asset.asset_id,
+                value=total_value,
+                recorded_at=datetime.utcnow(),
+                source='initial_creation',
+                adjusted_by=admin_user_id,  # Admin who created the asset
+                adjustment_reason='Initial asset creation'
+            )
+            
+            db.session.add(value_history)
+            db.session.commit()
+            
+            return {
+                'asset': asset,
+                'fraction': fraction,
+                'value_history': value_history
+            }
+            
+        except Exception as e:
+            # Rollback asset creation if fraction or history creation fails
+            db.session.rollback()
+            raise ValueError(f"Failed to create initial fraction or value history: {str(e)}")

--- a/app/views/asset_view.py
+++ b/app/views/asset_view.py
@@ -128,3 +128,21 @@ class AssetView:
     def render_adjustment_created(self, row):
         data = row.to_dict()
         return jsonify({"status": "created", "item": data}), 201
+    
+    def render_asset_with_fraction_created(self, result):
+        """
+        Render asset creation with initial fraction response.
+        
+        Args:
+            result: Dictionary containing asset, fraction, and value_history
+            
+        Returns:
+            Response: JSON response
+        """
+        return jsonify({
+            'asset': result['asset'].to_dict(),
+            'fraction': result['fraction'].to_dict(),
+            'value_history': result['value_history'].to_dict(),
+            'message': 'Asset created successfully with initial fraction and value history',
+            'status': 'success'
+        }), 201

--- a/fix_sequences.sql
+++ b/fix_sequences.sql
@@ -1,0 +1,58 @@
+-- Fix sequence synchronization issues after database import
+-- This script should be run after import_postgres.sql to ensure all sequences are properly synchronized
+
+-- Fix Users sequence
+SELECT setval('"Users_user_id_seq"', (SELECT MAX(user_id) FROM "Users"));
+
+-- Fix Assets sequence  
+SELECT setval('"Assets_asset_id_seq"', (SELECT MAX(asset_id) FROM "Assets"));
+
+-- Fix Fractions sequence
+SELECT setval('"Fractions_fraction_id_seq"', (SELECT MAX(fraction_id) FROM "Fractions"));
+
+-- Fix AssetValueHistory sequence
+SELECT setval('"AssetValueHistory_id_seq"', (SELECT MAX(id) FROM "AssetValueHistory"));
+
+-- Fix Offers sequence (if any offers exist)
+DO $$
+DECLARE
+    max_offer_id INTEGER;
+BEGIN
+    SELECT MAX(offer_id) INTO max_offer_id FROM "Offers";
+    IF max_offer_id IS NOT NULL THEN
+        PERFORM setval('"Offers_offer_id_seq"', max_offer_id);
+    END IF;
+END $$;
+
+-- Fix Transactions sequence (if any transactions exist)
+DO $$
+DECLARE
+    max_transaction_id INTEGER;
+BEGIN
+    SELECT MAX(transaction_id) INTO max_transaction_id FROM "Transactions";
+    IF max_transaction_id IS NOT NULL THEN
+        PERFORM setval('"Transactions_transaction_id_seq"', max_transaction_id);
+    END IF;
+END $$;
+
+-- Display current sequence values for verification
+\echo 'Current sequence values:'
+SELECT 'Users_user_id_seq' as sequence_name, last_value FROM "Users_user_id_seq"
+UNION ALL
+SELECT 'Assets_asset_id_seq', last_value FROM "Assets_asset_id_seq"
+UNION ALL
+SELECT 'Fractions_fraction_id_seq', last_value FROM "Fractions_fraction_id_seq"
+UNION ALL
+SELECT 'AssetValueHistory_id_seq', last_value FROM "AssetValueHistory_id_seq"
+UNION ALL
+SELECT 'Offers_offer_id_seq', last_value FROM "Offers_offer_id_seq"
+UNION ALL
+SELECT 'Transactions_transaction_id_seq', last_value FROM "Transactions_transaction_id_seq";
+
+\echo '✅ All sequences synchronized successfully!'
+\echo '   - Users sequence fixed'
+\echo '   - Assets sequence fixed' 
+\echo '   - Fractions sequence fixed'
+\echo '   - AssetValueHistory sequence fixed'
+\echo '   - Offers sequence fixed'
+\echo '   - Transactions sequence fixed'

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -93,8 +93,8 @@
         
           <div class="row">
             <div class="col">
-            <label>Total Units (Available Fractions)</label>
-            <input type="number" id="newAssetTotalUnits" required min="1" placeholder="Maximum number of fractions">
+            <label>Available Fractions</label>
+            <input type="number" id="newAssetTotalUnits" required min="1" placeholder="Maximum number of fractions" onchange="validateAssetUnits()">
             </div>
             <div class="col">
             <label>Initial Fraction Owner</label>
@@ -109,20 +109,22 @@
         
         <div class="row">
           <div class="col">
-            <label>Minimum Units per Fraction</label>
-            <input type="number" id="newAssetMinUnits" required min="1" placeholder="1">
+            <label>Minimum Number of Fractions</label>
+            <input type="number" id="newAssetMinUnits" required min="1" placeholder="1" onchange="validateAssetUnits()">
           </div>
           <div class="col">
-            <label>Maximum Units per Fraction</label>
-            <input type="number" id="newAssetMaxUnits" required min="1" placeholder="100">
+            <label>Maximum Number of Fraction</label>
+            <input type="number" id="newAssetMaxUnits" required min="1" placeholder="100" onchange="validateAssetUnits()">
         </div>
       </div>
         
         <div class="card" style="background: var(--background); margin: 15px 0; padding: 15px;">
-          <h4 style="margin: 0 0 10px 0; color: var(--accent);">Initial Fraction Details</h4>
+          <h4 style="margin: 0 0 10px 0; color: var(--accent);">Unit Constraints</h4>
           <p class="text-muted" style="margin: 0; font-size: 14px;">
-            The initial fraction will be created with all available units and assigned to the selected admin user.
-            Value per unit will be calculated as: Total Value ÷ Total Units
+            <strong>Validation Rules:</strong><br>
+            • Minimum Units ≤ Total Units ≤ Maximum Units<br>
+            • The initial fraction will be created with all available units and assigned to the selected admin user.<br>
+            • Value per unit will be calculated as: Total Value ÷ Total Units
           </p>
         </div>
         
@@ -821,52 +823,39 @@
         return;
       }
       
-      if (assetData.unit_max > assetData.total_unit) {
-        showMessage('Maximum units cannot be greater than total units', false);
+      if (assetData.total_unit < assetData.unit_min) {
+        showMessage('Total units cannot be less than minimum units', false);
+        return;
+      }
+      
+      if (assetData.total_unit > assetData.unit_max) {
+        showMessage('Total units cannot be greater than maximum units', false);
         return;
       }
       
       try {
-        // Step 1: Create the asset
-        showMessage('Creating asset...', true);
-        const assetResponse = await fetch(`${API}/assets`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(assetData)
-        });
+        // Create asset with initial fraction using the new endpoint
+        showMessage('Creating asset with initial fraction...', true);
         
-        if (!assetResponse.ok) {
-          const error = await assetResponse.json();
-          throw new Error(error.message || error.error || 'Failed to create asset');
-        }
-        
-        const assetResult = await assetResponse.json();
-        const assetId = assetResult.asset.asset_id;
-        
-        // Step 2: Create the initial fraction
-        showMessage('Creating initial fraction...', true);
-        const valuePerUnit = assetData.total_value / assetData.total_unit;
-        
-        const fractionData = {
-          asset_id: assetId,
+        const completeAssetData = {
+          ...assetData,
+          asset_description: document.getElementById('newAssetDescription').value || null,
           owner_id: parseInt(ownerId),
-          parent_fraction_id: null,
-          units: assetData.total_unit,
-          is_active: true,
-          value_perunit: Math.round(valuePerUnit * 100) / 100 // Round to 2 decimal places
+          adjusted_by: user.user_id
         };
         
-        const fractionResponse = await fetch(`${API}/fractions`, {
+        const response = await fetch(`${API}/assets/with-initial-fraction`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(fractionData)
+          body: JSON.stringify(completeAssetData)
         });
         
-        if (!fractionResponse.ok) {
-          const error = await fractionResponse.json();
-          throw new Error(error.message || error.error || 'Failed to create initial fraction');
+        if (!response.ok) {
+          const error = await response.json();
+          throw new Error(error.message || error.error || 'Failed to create asset with initial fraction');
         }
         
+        const result = await response.json();
         
         // Success!
         hideAddAssetModal();
@@ -914,6 +903,52 @@
       }
       sessionStorage.clear();
       location.href = 'login.html';
+    }
+
+    // Real-time validation for asset units
+    function validateAssetUnits() {
+      const totalUnits = parseInt(document.getElementById('newAssetTotalUnits').value) || 0;
+      const minUnits = parseInt(document.getElementById('newAssetMinUnits').value) || 0;
+      const maxUnits = parseInt(document.getElementById('newAssetMaxUnits').value) || 0;
+      
+      const totalUnitsInput = document.getElementById('newAssetTotalUnits');
+      const minUnitsInput = document.getElementById('newAssetMinUnits');
+      const maxUnitsInput = document.getElementById('newAssetMaxUnits');
+      
+      // Reset all field styles
+      totalUnitsInput.style.borderColor = '#ddd';
+      minUnitsInput.style.borderColor = '#ddd';
+      maxUnitsInput.style.borderColor = '#ddd';
+      
+      let hasError = false;
+      
+      // Validate min <= max
+      if (minUnits > 0 && maxUnits > 0 && minUnits > maxUnits) {
+        minUnitsInput.style.borderColor = '#f44336';
+        maxUnitsInput.style.borderColor = '#f44336';
+        hasError = true;
+      }
+      
+      // Validate total >= min (if both are set)
+      if (totalUnits > 0 && minUnits > 0 && totalUnits < minUnits) {
+        totalUnitsInput.style.borderColor = '#f44336';
+        minUnitsInput.style.borderColor = '#f44336';
+        hasError = true;
+      }
+      
+      // Validate total <= max (if both are set)
+      if (totalUnits > 0 && maxUnits > 0 && totalUnits > maxUnits) {
+        totalUnitsInput.style.borderColor = '#f44336';
+        maxUnitsInput.style.borderColor = '#f44336';
+        hasError = true;
+      }
+      
+      // If no errors and all fields have values, show success
+      if (!hasError && totalUnits > 0 && minUnits > 0 && maxUnits > 0) {
+        totalUnitsInput.style.borderColor = '#4CAF50';
+        minUnitsInput.style.borderColor = '#4CAF50';
+        maxUnitsInput.style.borderColor = '#4CAF50';
+      }
     }
 
     // Event listeners

--- a/init_db_postgres.py
+++ b/init_db_postgres.py
@@ -184,6 +184,7 @@ def main():
     script_dir = os.path.dirname(os.path.abspath(__file__))
     schema_file = os.path.join(script_dir, 'schema_postgres.sql')
     import_file = os.path.join(script_dir, 'import_postgres.sql')
+    fix_sequences_file = os.path.join(script_dir, 'fix_sequences.sql')
     
     # Execute schema creation
     if not execute_sql_file(database_config, schema_file, "Creating database schema"):
@@ -193,6 +194,11 @@ def main():
     # Execute data import
     if not execute_sql_file(database_config, import_file, "Importing initial data"):
         print("\n❌ Data import failed!")
+        sys.exit(1)
+    
+    # Fix sequence synchronization issues
+    if not execute_sql_file(database_config, fix_sequences_file, "Fixing sequence synchronization"):
+        print("\n❌ Sequence synchronization failed!")
         sys.exit(1)
     
     # Verify tables were created

--- a/schema_postgres.sql
+++ b/schema_postgres.sql
@@ -33,6 +33,7 @@ CREATE TABLE "Users" (
 CREATE TABLE "Assets" (
   asset_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
   asset_name TEXT NOT NULL,
+  asset_description TEXT,
   total_unit BIGINT NOT NULL,
   unit_min BIGINT NOT NULL,
   unit_max BIGINT NOT NULL,


### PR DESCRIPTION
Admin ability to create new assets, adding new fraction in auto and record initialised value in assetvaluehistory. have validation on adjusted_by needs to be true under is_manager, sequence check to ensure no duplicated primary key when adding new assets.

What have modified (extra):
1. Assets table adding one attribute: description (txt) information about the asset (required in real world situation)
2. adding file: fix_sequences.sql
fix_sequences.sql is a PostgreSQL sequence synchronization script that resolves auto-increment sequence desynchronization issues that occur when importing data with explicit ID values into PostgreSQL tables with GENERATED ALWAYS AS IDENTITY columns.

Issue is that:
When import_postgres.sql inserts data with explicit ID values (e.g., INSERT INTO "Users" (user_id, ...) VALUES (1, ...)), PostgreSQL sequences become desynchronized. The sequence counter remains at its initial value (typically 1) while the actual data contains higher IDs. This causes primary key constraint violations when trying to insert new records, as the sequence tries to generate IDs that already exist.

Workflow now:
The script is embedded and automatically executed in the database initialization workflow. 
This issue is raised if we have import data for transactions, when adding new record from frontend, the group might experience the same issue again, so it is noted here.
