### PR TITLE
add owning-fractions & user-transactions endpoints

### DIFF
--- a/app/controllers/portfolio_controller.py
+++ b/app/controllers/portfolio_controller.py
@@ -1,0 +1,31 @@
+from flask import request
+from app.services.portfolio_service import PortfolioService
+from app.views.portfolio_view import PortfolioView
+
+class PortfolioController:
+    def __init__(self):
+        self.service = PortfolioService()
+        self.view = PortfolioView()
+
+    def owning_fractions(self, user_id: int):
+        try:
+            data = self.service.user_owning_fractions(user_id)
+            return self.view.render_owning(user_id, data)
+        except Exception as e:
+            return self.view.render_error(str(e), 500)
+
+    def user_transactions(self, user_id: int):
+        try:
+            page = request.args.get("page", 1, type=int)
+            per_page = request.args.get("per_page", 20, type=int)
+            asset_id = request.args.get("asset_id", type=int)
+
+            items, total = self.service.user_transactions(
+                user_id=user_id,
+                asset_id=asset_id,
+                page=page,
+                per_page=per_page,
+            )
+            return self.view.render_user_transactions(user_id, items, total, page, per_page)
+        except Exception as e:
+            return self.view.render_error(str(e), 500)

--- a/app/routes/portfolio.py
+++ b/app/routes/portfolio.py
@@ -1,0 +1,15 @@
+from flask import Blueprint
+from app.controllers.portfolio_controller import PortfolioController
+
+bp = Blueprint("portfolio", __name__, url_prefix="/users")
+controller = PortfolioController()
+
+# User holdings (aggregated, grouped by asset + current valuation)
+@bp.route("/<int:user_id>/fractions/owning", methods=["GET"])
+def owning_fractions(user_id):
+    return controller.owning_fractions(user_id)
+
+# User-related transaction history (filterable by asset_id, with paging)
+@bp.route("/<int:user_id>/transactions", methods=["GET"])
+def user_transactions(user_id):
+    return controller.user_transactions(user_id)

--- a/app/services/portfolio_service.py
+++ b/app/services/portfolio_service.py
@@ -1,0 +1,79 @@
+from typing import List, Dict, Any, Optional, Tuple
+from sqlalchemy import func, or_
+from app import db
+from app.models import Fraction, Asset, AssetValueHistory, Transaction
+
+class PortfolioService:
+    """Provide aggregated owning-fractions + user transaction history."""
+
+    @staticmethod
+    def user_owning_fractions(user_id: int) -> List[Dict[str, Any]]:
+        """
+        Return user's holding grouped by asset, including latest value & est. value.
+        """
+        # Total shares held for each asset
+        rows = (
+            db.session.query(
+                Fraction.asset_id,
+                func.sum(Fraction.units).label("units"),
+            )
+            .filter(Fraction.owner_id == user_id, Fraction.is_active == True)  # noqa: E712
+            .group_by(Fraction.asset_id)
+            .all()
+        )
+
+        if not rows:
+            return []
+
+        # Find information of these assets
+        asset_ids = [r.asset_id for r in rows]
+        assets = {
+            a.asset_id: a for a in Asset.query.filter(Asset.asset_id.in_(asset_ids)).all()
+        }
+
+        # Get the latest price for each asset
+        result: List[Dict[str, Any]] = []
+        for r in rows:
+            aid = r.asset_id
+            units = int(r.units or 0)
+            latest = (
+                AssetValueHistory.query
+                .filter(AssetValueHistory.asset_id == aid)
+                .order_by(AssetValueHistory.recorded_at.desc())
+                .first()
+            )
+            latest_value = float(latest.value) if latest else float(assets[aid].total_value)
+
+            result.append({
+                "asset_id": aid,
+                "asset_name": assets[aid].asset_name if aid in assets else None,
+                "units": units,
+                "latest_value": latest_value,
+                "estimated_value": round(units * latest_value, 2),
+            })
+        return result
+
+    @staticmethod
+    def user_transactions(
+        user_id: int,
+        asset_id: Optional[int] = None,
+        page: int = 1,
+        per_page: int = 20,
+    ) -> Tuple[List[Transaction], int]:
+        """
+        Return user's related transactions (buy/sell/transfer), time-desc, with optional asset filter.
+        """
+        q = (
+            db.session.query(Transaction)
+            .join(Fraction, Transaction.fraction_id == Fraction.fraction_id)
+            .filter(or_(
+                Transaction.from_owner_id == user_id,
+                Transaction.to_owner_id == user_id
+            ))
+        )
+        if asset_id:
+            q = q.filter(Fraction.asset_id == asset_id)
+
+        q = q.order_by(Transaction.transaction_at.desc())
+        pagination = q.paginate(page=page, per_page=per_page, error_out=False)
+        return pagination.items, pagination.total

--- a/app/views/portfolio_view.py
+++ b/app/views/portfolio_view.py
@@ -1,0 +1,29 @@
+from typing import List, Dict, Any
+from flask import jsonify
+from app.models import Transaction
+
+class PortfolioView:
+    def render_owning(self, user_id: int, items: List[Dict[str, Any]]):
+        return jsonify({
+            "user_id": user_id,
+            "count": len(items),
+            "items": items,
+            "status": "success",
+        })
+
+    def render_user_transactions(self, user_id: int, items: List[Transaction], total: int, page: int, per_page: int):
+        return jsonify({
+            "user_id": user_id,
+            "page": page,
+            "per_page": per_page,
+            "total": total,
+            "items": [t.to_dict() for t in items],
+            "status": "success",
+        })
+
+    def render_error(self, message: str, status_code: int):
+        return jsonify({
+            "error": "Portfolio Error",
+            "message": message,
+            "status_code": status_code,
+        }), status_code


### PR DESCRIPTION
Add two read-only portfolio APIs for user holdings & transaction history.

### Endpoints
- `GET /users/<int:user_id>/fractions/owning`
  - Aggregate user’s holdings by asset with:
    - `units`, `asset_name`, `latest_value` (from `AssetValueHistory`, fallback to `Assets.total_value`), `estimated_value = units * latest_value`
- `GET /users/<int:user_id>/transactions?asset_id=&page=&per_page=`
  - List user-related transactions (buy/sell/transfer), time-desc
  - Supports optional `asset_id` filter and pagination (`page`, `per_page`)
  
### Implementation
- `app/routes/portfolio.py` – blueprint & routes
- `app/controllers/portfolio_controller.py` – request handling
- `app/services/portfolio_service.py` – DB queries & aggregation
- `app/views/portfolio_view.py` – unified JSON responses

### Notes
- **No schema changes**
- Uses existing models: `Fraction`, `Asset`, `AssetValueHistory`, `Transaction`
- Backward compatible; read-only

### How to test (examples)
```powershell
# holdings
Invoke-RestMethod "http://127.0.0.1:5001/users/1/fractions/owning"

# transactions (page 1, 20 per page)
Invoke-RestMethod "http://127.0.0.1:5001/users/1/transactions?page=1&per_page=20"

# transactions for a specific asset
Invoke-RestMethod "http://127.0.0.1:5001/users/1/transactions?asset_id=5&page=1&per_page=20"